### PR TITLE
feat: support dynamic path

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,20 @@ Datahub can also automatically generate an API document from your mock/testing d
 
 ### DataHub Dashboard
 
-DataHub adopts multi-scenario design, can group data according to the scene name, and provide scene data addition, deletion, and change, and can operate through DataHub's panel interface
+DataHub adopts multi-scenario design, can group data according to the scene name, and provide scene data addition, deletion, and change, and can operate through DataHub's panel interface.
 
 DataHub provides a dashboard for you to manage your data. You can group data by scene, or by stage such as development, testing, or staging. Datahub provides standard CRUD funtions.
+
+Datahub use [path-to-regexp](https://github.com/pillarjs/path-to-regexp) for dynamic path matching.
+
+API name example:
+
+| DataHub API name | matched request path |
+| ----             | ----                 |
+| api1/books       | api1/books           |
+| api2/:foo/:bar   | api2/group/project   |
+| api3/:id         | api3/aaaaa           |
+| api3/:id         | api3/bbbbb           |
 
 <div align="center">
   <img src="https://wx4.sinaimg.cn/large/6d308bd9gy1fpbmdxv2ehj21kw13awr0.jpg" width="75%" />

--- a/README.zh.md
+++ b/README.zh.md
@@ -46,6 +46,15 @@ DataHub 将 Mock 数据与字段描述整合处理，自动生成接口文档。
 
 DataHub 采用多场景设计，能够根据场景名称进行数据分组，同时提供了场景数据的增、删、改，可以通过 DataHub 的面板界面进行操作。
 
+Datahub 可以定义动态路径，底层使用的是 [path-to-regexp](https://github.com/pillarjs/path-to-regexp) 。
+
+| DataHub API 定义 | 匹配的 URL 路径      |
+| ----             | ----                 |
+| api1/books       | api1/books           |
+| api2/:foo/:bar   | api2/group/project   |
+| api3/:id         | api3/aaaaa           |
+| api3/:id         | api3/bbbbb           |
+
 <div align="center">
   <img src="https://wx3.sinaimg.cn/large/6d308bd9gy1fpbm9x6ctkj21kw13a16k.jpg" width="75%" />
 </div>

--- a/app/controller/api/data.js
+++ b/app/controller/api/data.js
@@ -16,7 +16,6 @@ class DataController extends Controller {
   /**
    * index router just for http service
    */
-
   async index() {
     const ctx = this.ctx;
     const projectId = ctx.params.projectId;

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "macaca-logo": "^1.0.0",
     "mz": "^2.7.0",
     "npm-update": "^1.0.6",
+    "path-to-regexp": "^2.2.1",
     "request": "^2.85.0",
     "semver": "^5.5.0",
     "socket.io": "^2.0.4",


### PR DESCRIPTION
example:

- DataHub router `api/:foo/:bar` will match request path `api/aaaa/bbbb`
- now the value of `foo` and `bar` are just captured in `__pathParam ` as  `{ foo: 'some_value', bar: 'some_value'}` but not affect the current scene

use https://github.com/pillarjs/path-to-regexp for parameter parse

Closes #62, Closes #57