### PR TITLE
feat: use cdn.jsdelivr.net by default

### DIFF
--- a/config/config.default.js
+++ b/config/config.default.js
@@ -47,7 +47,7 @@ module.exports = appInfo => {
   };
 
   config.dataHubView = {
-    assetsUrl: 'https://unpkg.com/datahub-view@2',
+    assetsUrl: 'https://cdn.jsdelivr.net/npm/datahub-view@2',
   };
 
   config.dataHubRpcType = process.env.DATAHUB_RPC_PROTOCOL || 'http';


### PR DESCRIPTION
- cdn.jsdelivr.net is a global CDN service
- it also supports major version auto update like unpkg.com