### PR TITLE
feat: add prettier config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+docs
+docs_dist
 data
 coverage
 node_modules

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,8 +1,0 @@
-{
-  "extends": "eslint-config-egg",
-  "parserOptions": {
-    "ecmaFeatures": {
-      "experimentalObjectRestSpread": true
-    }
-  }
-}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  root: true,
+  extends: ['egg', 'prettier'],
+};

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+.vscode
+docs
+docs_dist
+run
+log
+logo

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 120
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "macaca-datahub": "./bin/datahub.js"
   },
   "scripts": {
-    "start": "npm run db:migrate && eggctl start --port=9200 --title=egg-server-datahub",
+    "start": "npm run db:migrate && eggctl start --port=9200 --title=egg-server-datahub --workers=1",
     "stop": "eggctl stop --title=egg-server-datahub",
     "start:use-config": "./bin/datahub.js server -c ./macaca-datahub.config.js --verbose",
     "dev": "npm run db:migrate && egg-bin dev",
@@ -63,11 +63,13 @@
     "egg-bin": "^4.3.6",
     "egg-ci": "^1.8.0",
     "egg-mock": "^3.13.1",
-    "eslint": "^4.12.1",
-    "eslint-config-egg": "^5.1.1",
+    "eslint": "^5.11.0",
+    "eslint-config-egg": "^7.1.0",
+    "eslint-config-prettier": "^4.1.0",
     "git-contributor": "1",
     "husky": "^1.3.1",
     "macaca-ecosystem": "*",
+    "prettier": "^2.0.5",
     "vuepress": "^1.5.2",
     "webstorm-disable-index": "^1.2.0"
   },


### PR DESCRIPTION
- init prettier config
- limit egg worker process number to 1, instead of the os cpu numbers, by default `npm  start` egg will create 32 worker processes in a 32 core cpu machine, it's helpful for large cluster environment.