### PR TITLE
fix: add ./bin/datahub-server.js tinto bin field in pkg.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Continuous data provider for development, testing, staging and production.",
   "bin": {
     "datahub": "./bin/datahub.js",
-    "macaca-datahub": "./bin/datahub.js"
+    "macaca-datahub": "./bin/datahub.js",
+    "macaca-server": "./bin/datahub-server.js"
   },
   "files": [
     "app/**/*.js",


### PR DESCRIPTION
由于 egg-datahub 中会通过 spawn 执行 datahub-server.js，会出现没有执行权限和 crlf 报错，因此将该文件放到 bin 中